### PR TITLE
Openpnm time step to experiment period

### DIFF
--- a/jellybamm/__liionsolve__.py
+++ b/jellybamm/__liionsolve__.py
@@ -111,7 +111,7 @@ def run_simulation_lp(parameter_values, experiment, initial_soc, project):
     ###########################################################################
     # New Liionpack code                                                      #
     ###########################################################################
-    dim_time_step = 10
+    dim_time_step = experiment.period
     neg_econd, pos_econd = jellybamm.cc_cond(project, parameter_values)
     Rs = 1e-2  # series resistance
     Ri = 90  # initial guess for internal resistance


### PR DESCRIPTION
Changing the time step of the openpnm thermal diffusion solve step to equal the experiment period